### PR TITLE
PNP-12234 Test helper optimizations and fixes

### DIFF
--- a/Helper/RequestHelper.php
+++ b/Helper/RequestHelper.php
@@ -561,6 +561,10 @@ class RequestHelper
             call_user_func($callback, $this);
         }
 
+        if ($this->client->getKernel()->getContainer() !== null) {
+            $this->client->getKernel()->getContainer()->get('doctrine')->getManager()->clear();
+        }
+
         return $this;
     }
 

--- a/Helper/ServiceTestCaseTrait.php
+++ b/Helper/ServiceTestCaseTrait.php
@@ -125,4 +125,14 @@ trait ServiceTestCaseTrait
         $application->setDispatcher($container->get('event_dispatcher'));
         return new CommandHelper($container, $application->find($commandName));
     }
+
+    /**
+     * Overriding Symfony's default teatDown method, which reboots kernel after each test, which is very slow.
+     *
+     * Kernel or client reboots should be added manually to the tests that really need it.
+     */
+    protected function tearDown()
+    {
+        // This method is doing nothing intentionally. If you need to add some code here, feel free to do so.
+    }
 }

--- a/Helper/WebTestCaseTrait.php
+++ b/Helper/WebTestCaseTrait.php
@@ -70,13 +70,12 @@ trait WebTestCaseTrait
 
     /**
      * Overriding Symfony's default teatDown method, which reboots kernel after each test, which is very slow.
-     * Instead we'd rather clear entity managers' cache, which is often quite useful and extremely fast.
      *
      * Kernel or client reboots should be added manually to the tests that really need it.
      */
     protected function tearDown()
     {
-        static::clearClientEntityManagerCache();
+        // This method is doing nothing intentionally. If you need to add some code here, feel free to do so.
     }
 
     protected static function clearClientEntityManagerCache($client = null)


### PR DESCRIPTION
It's better if we clear client's entity manager after each request, not after each test. It solves some test failures happening due to refreshed data not fetched from DB.

Also added empty tearDown into ServiceTestCaseTrait.php to ensure we override Symfony's kernel reboots in tests that use only that trait.