### PR TITLE
PNP-12234 NonRebootableKernelTestTrait

### DIFF
--- a/Helper/NonRebootableKernelTestTrait.php
+++ b/Helper/NonRebootableKernelTestTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Draw\Bundle\DrawTestHelperBundle\Helper;
+
+
+trait NonRebootableKernelTestTrait
+{
+
+    /**
+     * Overriding Symfony's default teatDown method, which reboots kernel after each test, which is very slow.
+     *
+     * Kernel or client reboots should be added manually to the tests that really need it.
+     */
+    protected function tearDown()
+    {
+        // This method is doing nothing intentionally. If you need to add some code here, feel free to do so.
+    }
+}

--- a/Helper/ServiceTestCaseTrait.php
+++ b/Helper/ServiceTestCaseTrait.php
@@ -7,6 +7,8 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 
 trait ServiceTestCaseTrait
 {
+    use NonRebootableKernelTestTrait;
+
     /**
      * @var bool
      */
@@ -126,13 +128,4 @@ trait ServiceTestCaseTrait
         return new CommandHelper($container, $application->find($commandName));
     }
 
-    /**
-     * Overriding Symfony's default teatDown method, which reboots kernel after each test, which is very slow.
-     *
-     * Kernel or client reboots should be added manually to the tests that really need it.
-     */
-    protected function tearDown()
-    {
-        // This method is doing nothing intentionally. If you need to add some code here, feel free to do so.
-    }
 }

--- a/Helper/WebTestCaseTrait.php
+++ b/Helper/WebTestCaseTrait.php
@@ -6,6 +6,8 @@ use Symfony\Bundle\FrameworkBundle\Client;
 
 trait WebTestCaseTrait
 {
+    use NonRebootableKernelTestTrait;
+
     /**
      * @var Client
      */
@@ -66,16 +68,6 @@ trait WebTestCaseTrait
     {
         gc_enable();
         gc_collect_cycles();
-    }
-
-    /**
-     * Overriding Symfony's default teatDown method, which reboots kernel after each test, which is very slow.
-     *
-     * Kernel or client reboots should be added manually to the tests that really need it.
-     */
-    protected function tearDown()
-    {
-        // This method is doing nothing intentionally. If you need to add some code here, feel free to do so.
     }
 
     protected static function clearClientEntityManagerCache($client = null)


### PR DESCRIPTION
Moved duplicate code to a new trait.
This test helper is also now used in tests that didn't have kernel reboot override, because they were extending Symfony's WebTestCase (which reboots kernel) but didn't use ServiceTestCaseTrait or WebTestCaseTrait.